### PR TITLE
Feature/typesAdd TypeScript support with type declarationsipt typings and exampled

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,114 @@ Use the npm to install the project.
 npm install @turbodocx/html-to-docx
 ```
 
+### TypeScript Support
+
+This package includes TypeScript typings. No additional installation is required to use it with TypeScript projects.
+
+### TypeScript Example
+
+```typescript
+import HtmlToDocx from "@turbodocx/html-to-docx";
+
+const htmlString = `<!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <meta charset="UTF-8" />
+            <title>Document</title>
+        </head>
+        <body>
+            <h1>Hello world</h1>
+        </body>
+    </html>`;
+
+// Basic usage
+async function basicExample() {
+  const docx = await HtmlToDocx(htmlString);
+  // docx is ArrayBuffer in Node.js or Blob in browser environments
+}
+
+// With header
+async function withHeader() {
+  const headerHtml = "<p>Document Header</p>";
+  const docx = await HtmlToDocx(htmlString, headerHtml);
+}
+
+// With document options
+async function withOptions() {
+  const docx = await HtmlToDocx(htmlString, null, {
+    orientation: "landscape",
+    title: "TypeScript Example",
+    creator: "TurboDocx",
+    table: {
+      row: {
+        cantSplit: true,
+      },
+      borderOptions: {
+        size: 1,
+        color: "000000"
+      }
+    },
+    pageNumber: true,
+    footer: true
+  });
+}
+
+// With all parameters
+async function complete() {
+  const headerHtml = "<p>Document Header</p>";
+  const footerHtml = "<p>Page Footer</p>";
+  
+  const docx = await HtmlToDocx(
+    htmlString,
+    headerHtml,
+    {
+      orientation: "landscape",
+      pageSize: {
+        width: 12240,
+        height: 15840
+      },
+      margins: {
+        top: 1440,
+        right: 1800,
+        bottom: 1440,
+        left: 1800
+      },
+      title: "Complete Example",
+      creator: "TurboDocx",
+    },
+    footerHtml
+  );
+}
+
+For more comprehensive TypeScript examples, check out the following files in the `example/typescript` directory:
+
+- `typescript-example.ts` - A complete example showing how to generate and save DOCX files using TypeScript
+- `type-test.ts` - Demonstrates the type checking capabilities provided by the TypeScript definitions
+
+### Running the TypeScript Examples
+
+To run the TypeScript examples:
+
+```bash
+# Navigate to the example directory
+cd example/typescript
+
+# Install ts-node globally (if not already installed)
+npm install -g ts-node typescript
+
+# Ensure @turbodocx/html-to-docx is built and accessible
+# From the root directory of the project:
+# npm install
+# npm run build
+
+# Run the TypeScript example directly
+ts-node typescript-example.ts
+```
+
+This will generate two DOCX files in the `example/typescript` directory:
+- `basic-example.docx` - A simple document with minimal configuration
+- `advanced-example.docx` - A document with headers, footers, and advanced formatting options
+
 ## Usage
 
 ```js

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ async function complete() {
     footerHtml
   );
 }
+```
 
 For more comprehensive TypeScript examples, check out the following files in the `example/typescript` directory:
 

--- a/example/typescript/tsconfig.json
+++ b/example/typescript/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@turbodocx/html-to-docx": ["../../"]
+    }
+  },
+  "include": [
+    "*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+} 

--- a/example/typescript/type-test.ts
+++ b/example/typescript/type-test.ts
@@ -1,0 +1,68 @@
+/**
+ * This file demonstrates TypeScript type checking
+ * It's not meant to be executed, but rather to test type definitions
+ */
+
+import HTMLtoDOCX from "@turbodocx/html-to-docx";
+
+const htmlString = `<!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <meta charset="UTF-8" />
+            <title>Document</title>
+        </head>
+        <body>
+            <h1>Hello world</h1>
+        </body>
+    </html>`;
+
+// $ExpectType Promise<Blob> | Promise<ArrayBuffer>
+const doc1 = HTMLtoDOCX(htmlString);
+
+// $ExpectType Promise<Blob> | Promise<ArrayBuffer>
+const doc2 = HTMLtoDOCX(htmlString, "<p>Header</p>");
+
+// $ExpectType Promise<Blob> | Promise<ArrayBuffer>
+const doc3 = HTMLtoDOCX(htmlString, null, {
+    orientation: "landscape",
+    table: {
+        row: {
+            cantSplit: true,
+        },
+    },
+});
+
+// $ExpectType Promise<Blob> | Promise<ArrayBuffer>
+const doc4 = HTMLtoDOCX(
+    htmlString,
+    null,
+    {
+        orientation: "landscape",
+        table: {
+            row: {
+                cantSplit: true,
+            },
+        },
+    },
+    "<p>Footer</p>",
+);
+
+// @ts-expect-error - This should show a TypeScript error because parameters are in wrong order
+const doc5 = HTMLtoDOCX(htmlString, {
+    orientation: "landscape",
+    table: {
+        row: {
+            cantSplit: true,
+        },
+    },
+});
+
+const doc6 = HTMLtoDOCX(htmlString, null, {
+    // @ts-expect-error - This should show a TypeScript error because orientation has invalid value
+    orientation: "invalid",
+});
+
+const doc7 = HTMLtoDOCX(htmlString, null, {
+    // @ts-expect-error - This should show a TypeScript error because headerType has invalid value
+    headerType: "invalid",
+}); 

--- a/example/typescript/typescript-example.ts
+++ b/example/typescript/typescript-example.ts
@@ -48,26 +48,31 @@ const htmlString = `<!DOCTYPE html>
 const headerHtml = `<p style="text-align: right;">TurboDocx Example</p>`;
 const footerHtml = `<p style="text-align: center;">Page <span id="pageNumber">X</span> of <span id="totalPages">Y</span></p>`;
 
+async function saveDocxFile(docResult: Buffer | ArrayBuffer | Blob, fileName: string, docType: string) {
+    let docData: Buffer;
+    if (docResult instanceof Buffer) {
+        docData = docResult;
+    } else if (docResult instanceof ArrayBuffer) {
+        docData = Buffer.from(docResult);
+    } else if (typeof Blob !== 'undefined' && docResult instanceof Blob) {
+        console.log(`Received Blob for ${docType}, converting to ArrayBuffer then Buffer...`);
+        const arrayBuffer = await docResult.arrayBuffer();
+        docData = Buffer.from(arrayBuffer);
+    } else {
+        console.error(`Unexpected result type for ${docType}:`, typeof docResult);
+        // @ts-ignore
+        console.log(`${docType} constructor name:`, docResult?.constructor?.name);
+        return;
+    }
+    fs.writeFileSync(path.join(__dirname, fileName), docData);
+    console.log(`${docType} document created: ${fileName}`);
+}
+
 async function generateDocuments() {
     try {
         // Basic example
         const basicDocResult = await HTMLtoDOCX(htmlString);
-        let basicDocData: Buffer | Uint8Array;
-        if (basicDocResult instanceof Buffer) {
-            basicDocData = basicDocResult;
-        } else if (basicDocResult instanceof ArrayBuffer) {
-            basicDocData = Buffer.from(basicDocResult);
-        } else if (typeof Blob !== 'undefined' && basicDocResult instanceof Blob) {
-            console.log("Received Blob for basicDocResult, converting to ArrayBuffer then Buffer...");
-            const arrayBuffer = await basicDocResult.arrayBuffer();
-            basicDocData = Buffer.from(arrayBuffer);
-        } else {
-            console.error("Unexpected result type for basicDocResult:", typeof basicDocResult);
-            console.log("basicDocResult constructor name:", basicDocResult?.constructor?.name);
-            return;
-        }
-        fs.writeFileSync(path.join(__dirname, "basic-example.docx"), basicDocData);
-        console.log("Basic document created: basic-example.docx");
+        await saveDocxFile(basicDocResult, "basic-example.docx", "Basic");
 
         // Advanced example with all options
         const advancedDocResult = await HTMLtoDOCX(
@@ -112,22 +117,7 @@ async function generateDocuments() {
             footerHtml
         );
         
-        let advancedDocData: Buffer | Uint8Array;
-        if (advancedDocResult instanceof Buffer) {
-            advancedDocData = advancedDocResult;
-        } else if (advancedDocResult instanceof ArrayBuffer) {
-            advancedDocData = Buffer.from(advancedDocResult);
-        } else if (typeof Blob !== 'undefined' && advancedDocResult instanceof Blob) {
-            console.log("Received Blob for advancedDocResult, converting to ArrayBuffer then Buffer...");
-            const arrayBuffer = await advancedDocResult.arrayBuffer();
-            advancedDocData = Buffer.from(arrayBuffer);
-        } else {
-            console.error("Unexpected result type for advancedDocResult:", typeof advancedDocResult);
-            console.log("advancedDocResult constructor name:", advancedDocResult?.constructor?.name);
-            return;
-        }
-        fs.writeFileSync(path.join(__dirname, "advanced-example.docx"), advancedDocData);
-        console.log("Advanced document created: advanced-example.docx");
+        await saveDocxFile(advancedDocResult, "advanced-example.docx", "Advanced");
         
     } catch (error) {
         console.error("Error generating documents:", error);

--- a/example/typescript/typescript-example.ts
+++ b/example/typescript/typescript-example.ts
@@ -1,0 +1,137 @@
+import HTMLtoDOCX from "@turbodocx/html-to-docx";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * This file demonstrates how to use html-to-docx with TypeScript
+ * Run with ts-node or compile with tsc and then run with node
+ */
+
+const htmlString = `<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>TypeScript Example</title>
+    </head>
+    <body>
+        <h1>Hello from TypeScript</h1>
+        <p>This document was created using TypeScript and html-to-docx</p>
+        
+        <h2>Features</h2>
+        <ul>
+            <li>Convert HTML to DOCX</li>
+            <li>Full TypeScript support</li>
+            <li>Customizable options</li>
+        </ul>
+        
+        <table border="1">
+            <tr>
+                <th>Feature</th>
+                <th>Supported</th>
+            </tr>
+            <tr>
+                <td>Headers and Footers</td>
+                <td>Yes</td>
+            </tr>
+            <tr>
+                <td>Custom Page Size</td>
+                <td>Yes</td>
+            </tr>
+            <tr>
+                <td>Tables</td>
+                <td>Yes</td>
+            </tr>
+        </table>
+    </body>
+</html>`;
+
+const headerHtml = `<p style="text-align: right;">TurboDocx Example</p>`;
+const footerHtml = `<p style="text-align: center;">Page <span id="pageNumber">X</span> of <span id="totalPages">Y</span></p>`;
+
+async function generateDocuments() {
+    try {
+        // Basic example
+        const basicDocResult = await HTMLtoDOCX(htmlString);
+        let basicDocData: Buffer | Uint8Array;
+        if (basicDocResult instanceof Buffer) {
+            basicDocData = basicDocResult;
+        } else if (basicDocResult instanceof ArrayBuffer) {
+            basicDocData = Buffer.from(basicDocResult);
+        } else if (typeof Blob !== 'undefined' && basicDocResult instanceof Blob) {
+            console.log("Received Blob for basicDocResult, converting to ArrayBuffer then Buffer...");
+            const arrayBuffer = await basicDocResult.arrayBuffer();
+            basicDocData = Buffer.from(arrayBuffer);
+        } else {
+            console.error("Unexpected result type for basicDocResult:", typeof basicDocResult);
+            console.log("basicDocResult constructor name:", basicDocResult?.constructor?.name);
+            return;
+        }
+        fs.writeFileSync(path.join(__dirname, "basic-example.docx"), basicDocData);
+        console.log("Basic document created: basic-example.docx");
+
+        // Advanced example with all options
+        const advancedDocResult = await HTMLtoDOCX(
+            htmlString,
+            headerHtml,
+            {
+                orientation: "portrait",
+                pageSize: {
+                    width: 12240, // Letter width in TWIP
+                    height: 15840 // Letter height in TWIP
+                },
+                margins: {
+                    top: 1440,
+                    right: 1800,
+                    bottom: 1440,
+                    left: 1800,
+                    header: 720,
+                    footer: 720
+                },
+                title: "TypeScript Example",
+                subject: "HTML to DOCX Conversion",
+                creator: "TurboDocx",
+                keywords: ["html", "docx", "typescript", "conversion"],
+                description: "An example document created with html-to-docx and TypeScript",
+                lastModifiedBy: "TypeScript Example",
+                revision: 1,
+                header: true,
+                headerType: "default",
+                footer: true,
+                footerType: "default",
+                pageNumber: true,
+                table: {
+                    row: {
+                        cantSplit: true
+                    },
+                    borderOptions: {
+                        size: 2,
+                        color: "000000"
+                    }
+                }
+            },
+            footerHtml
+        );
+        
+        let advancedDocData: Buffer | Uint8Array;
+        if (advancedDocResult instanceof Buffer) {
+            advancedDocData = advancedDocResult;
+        } else if (advancedDocResult instanceof ArrayBuffer) {
+            advancedDocData = Buffer.from(advancedDocResult);
+        } else if (typeof Blob !== 'undefined' && advancedDocResult instanceof Blob) {
+            console.log("Received Blob for advancedDocResult, converting to ArrayBuffer then Buffer...");
+            const arrayBuffer = await advancedDocResult.arrayBuffer();
+            advancedDocData = Buffer.from(arrayBuffer);
+        } else {
+            console.error("Unexpected result type for advancedDocResult:", typeof advancedDocResult);
+            console.log("advancedDocResult constructor name:", advancedDocResult?.constructor?.name);
+            return;
+        }
+        fs.writeFileSync(path.join(__dirname, "advanced-example.docx"), advancedDocData);
+        console.log("Advanced document created: advanced-example.docx");
+        
+    } catch (error) {
+        console.error("Error generating documents:", error);
+    }
+}
+
+generateDocuments(); 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,82 @@
+/// <reference types="node" />
+
+declare namespace HTMLtoDOCX {
+    interface Margins {
+        top?: number;
+        right?: number;
+        bottom?: number;
+        left?: number;
+        header?: number;
+        footer?: number;
+        gutter?: number;
+    }
+
+    interface PageSize {
+        width?: number;
+        height?: number;
+    }
+
+    interface Row {
+        cantSplit?: boolean;
+    }
+
+    interface Table {
+        row?: Row;
+        borderOptions?: {
+            size?: number;
+            stroke?: string;
+            color?: string;
+        };
+        addSpacingAfter?: boolean;
+    }
+
+    interface LineNumberOptions {
+        start: number;
+        countBy: number;
+        restart: "continuous" | "newPage" | "newSection";
+    }
+
+    interface DocumentOptions {
+        orientation?: "portrait" | "landscape";
+        pageSize?: PageSize;
+        margins?: Margins;
+        title?: string;
+        subject?: string;
+        creator?: string;
+        keywords?: string[];
+        description?: string;
+        lastModifiedBy?: string;
+        revision?: number;
+        createdAt?: Date;
+        modifiedAt?: Date;
+        headerType?: "default" | "first" | "even";
+        header?: boolean;
+        footerType?: "default" | "first" | "even";
+        footer?: boolean;
+        font?: string;
+        fontSize?: number;
+        complexScriptFontSize?: number;
+        table?: Table;
+        pageNumber?: boolean;
+        skipFirstHeaderFooter?: boolean;
+        lineNumber?: boolean;
+        lineNumberOptions?: LineNumberOptions;
+        numbering?: {
+            defaultOrderedListStyleType?: string;
+        };
+        decodeUnicode?: boolean;
+        lang?: string;
+        preprocessing?: {
+            skipHTMLMinify?: boolean;
+        };
+    }
+}
+
+declare function HTMLtoDOCX(
+    htmlString: string,
+    headerHTMLstring?: string | null,
+    documentOptions?: HTMLtoDOCX.DocumentOptions,
+    footerHtmlString?: string | null,
+): Promise<ArrayBuffer | Blob | Buffer>;
+
+export = HTMLtoDOCX;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@turbodocx/html-to-docx",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@turbodocx/html-to-docx",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@oozcitak/dom": "1.15.6",
@@ -30,6 +30,7 @@
         "@rollup/plugin-commonjs": "^12.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.1.1",
+        "cross-env": "^7.0.3",
         "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-config-prettier": "^8.3.0",
@@ -42,7 +43,10 @@
         "rollup-plugin-cleaner": "^1.0.0",
         "rollup-plugin-node-builtins": "^2.1.2",
         "rollup-plugin-terser": "^7.0.2",
-        "standard-version": "^9.3.1"
+        "standard-version": "^9.3.1",
+        "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -266,6 +270,19 @@
         "node": ">=v12"
       }
     },
+    "node_modules/@commitlint/load/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/@commitlint/message": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-13.2.0.tgz",
@@ -368,6 +385,28 @@
         "node": ">=v12"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz",
@@ -384,6 +423,32 @@
       },
       "peerDependencies": {
         "cosmiconfig": ">=6"
+      }
+    },
+    "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader/node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -612,6 +677,30 @@
         "rollup": "^1.20.0||^2.0.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -694,6 +783,30 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk/node_modules/acorn": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/add-stream": {
@@ -1813,6 +1926,24 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2536,11 +2667,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
+    },
+    "node_modules/eslint-plugin-import/node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.1",
@@ -4020,15 +4175,15 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
       "bin": {
         "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/jsonfile": {
@@ -6423,41 +6578,72 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
       },
-      "engines": {
-        "node": ">=10.0.0"
-      },
       "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
         "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
       "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^2.2.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {
@@ -6502,16 +6688,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {
@@ -6569,6 +6755,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/validate-npm-package-license": {
@@ -6967,6 +7159,14 @@
         "lodash": "^4.17.19",
         "resolve-from": "^5.0.0",
         "typescript": "^4.4.3"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+          "dev": true
+        }
       }
     },
     "@commitlint/message": {
@@ -7047,6 +7247,27 @@
         "chalk": "^4.0.0"
       }
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
+    },
     "@endemolshinegroup/cosmiconfig-typescript-loader": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz",
@@ -7057,6 +7278,22 @@
         "make-error": "^1",
         "ts-node": "^9",
         "tslib": "^2"
+      },
+      "dependencies": {
+        "ts-node": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+          "dev": true,
+          "requires": {
+            "arg": "^4.1.0",
+            "create-require": "^1.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.17",
+            "yn": "3.1.1"
+          }
+        }
       }
     },
     "@eslint/eslintrc": {
@@ -7233,6 +7470,30 @@
         "picomatch": "^2.2.2"
       }
     },
+    "@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -7307,6 +7568,23 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.11.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.14.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+          "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+          "dev": true
+        }
+      }
     },
     "add-stream": {
       "version": "1.0.0",
@@ -8235,6 +8513,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -8817,11 +9104,32 @@
             "esutils": "^2.0.2"
           }
         },
+        "json5": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
+        },
+        "tsconfig-paths": {
+          "version": "3.15.0",
+          "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+          "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+          "dev": true,
+          "requires": {
+            "@types/json5": "^0.0.29",
+            "json5": "^1.0.2",
+            "minimist": "^1.2.6",
+            "strip-bom": "^3.0.0"
+          }
         }
       }
     },
@@ -9947,13 +10255,10 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -11860,27 +12165,41 @@
       "dev": true
     },
     "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.14.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+          "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+          "dev": true
+        }
       }
     },
     "tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
       "requires": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^2.2.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
@@ -11918,9 +12237,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true
     },
     "uglify-js": {
@@ -11966,6 +12285,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,12 @@
   "main": "dist/html-to-docx.umd.js",
   "module": "dist/html-to-docx.esm.js",
   "types": "index.d.ts",
+  "files": [
+    "dist",
+    "index.d.ts",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "test": "npm run build && node example/example-node.js",
     "prerelease": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbodocx/html-to-docx",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "HTML to DOCX converter",
   "keywords": [
     "html-to-docx",
@@ -34,10 +34,13 @@
     "document generation software",
     "automated document creation",
     "batch document generation",
-    "document templating"
+    "document templating",
+    "typescript",
+    "ts"
   ],
   "main": "dist/html-to-docx.umd.js",
   "module": "dist/html-to-docx.esm.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "npm run build && node example/example-node.js",
     "prerelease": "rollup -c",
@@ -46,7 +49,8 @@
     "prettier:check": "prettier --check '**/*.{js}'",
     "validate": "run-s lint prettier:check",
     "build": "rollup -c",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test:ts-example": "npm run build && cross-env TS_NODE_PROJECT=example/typescript/tsconfig.json ts-node -r tsconfig-paths/register example/typescript/typescript-example.ts"
   },
   "repository": {
     "type": "git",
@@ -89,6 +93,7 @@
     "@rollup/plugin-commonjs": "^12.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.1.1",
+    "cross-env": "^7.0.3",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.3.0",
@@ -101,7 +106,10 @@
     "rollup-plugin-cleaner": "^1.0.0",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-terser": "^7.0.2",
-    "standard-version": "^9.3.1"
+    "standard-version": "^9.3.1",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.8.3"
   },
   "dependencies": {
     "@oozcitak/dom": "1.15.6",


### PR DESCRIPTION
## Summary by Sourcery

Add official TypeScript support with type declarations and examples, and update package metadata and tooling accordingly.

New Features:
- Provide TypeScript type definitions for the HTML to DOCX converter API.
- Add runnable and type-checking TypeScript example files demonstrating usage and options.

Enhancements:
- Document TypeScript support and usage in the README, including instructions for running examples.
- Expose the type declaration file and examples via updated package metadata and published files list.

Build:
- Update package version to 1.13.0 and include TypeScript typings and related files in the published package.
- Add a script and dev dependencies to build and run the TypeScript example via ts-node.